### PR TITLE
Various perf adjustments

### DIFF
--- a/Scripts/Game/Core/WorldSystems/CSI_ClientSystem.c
+++ b/Scripts/Game/Core/WorldSystems/CSI_ClientSystem.c
@@ -216,7 +216,7 @@ class CSI_ClientSystem : GameSystem
 
 					muzzles.Clear();
 					// Get muzzle types (e.g., underslung grenade launcher)
-					for (int m = 0, mCount = weaponComp .GetMuzzlesList(muzzles); m < mCount; m++))
+					for (int m = 0, mCount = weaponComp .GetMuzzlesList(muzzles); m < mCount; m++)
 					{
 						// Convert muzzle types to weapon types (ToDo: Not hardcoded?)
 						EWeaponType muzzleWeaponType = -1;

--- a/Scripts/Game/Core/WorldSystems/CSI_ClientSystem.c
+++ b/Scripts/Game/Core/WorldSystems/CSI_ClientSystem.c
@@ -149,6 +149,7 @@ class CSI_ClientSystem : GameSystem
 			
 			array<IEntity> allPlayerItems = {};
 			characterInventory.GetItems(allPlayerItems);
+			array<BaseMuzzleComponent> muzzles = {};
 			// Parse through all items.
 			foreach (IEntity item : allPlayerItems)
 			{	
@@ -213,9 +214,9 @@ class CSI_ClientSystem : GameSystem
 					if (validDisplayIcons.Contains(CSI_EIcon.MG))
 						break;
 
-					array<BaseMuzzleComponent> muzzles = {};						
+					muzzles.Clear();
 					// Get muzzle types (e.g., underslung grenade launcher)
-					for (int m = 0, mCount = weaponComp .GetMuzzlesList(muzzles); m < mCount; m++)
+					for (int m = 0, mCount = weaponComp .GetMuzzlesList(muzzles); m < mCount; m++))
 					{
 						// Convert muzzle types to weapon types (ToDo: Not hardcoded?)
 						EWeaponType muzzleWeaponType = -1;

--- a/Scripts/Game/Core/WorldSystems/CSI_HUDSystem.c
+++ b/Scripts/Game/Core/WorldSystems/CSI_HUDSystem.c
@@ -182,9 +182,10 @@ class CSI_HUDSystem : GameSystem
 
 		tempLocalGroupArray.Sort(false);
 
+		array<string> outPlayerStrArray = {};
 		foreach (string playerStr : tempLocalGroupArray) 
 		{
-			array<string> outPlayerStrArray = {};
+			outPlayerStrArray.Clear();
 			playerStr.Split(";", outPlayerStrArray, false);
 			
 			playersGroupArray.Insert(outPlayerStrArray[1].ToInt());

--- a/Scripts/Game/UI/HUD/Elements/CSI_Radar.c
+++ b/Scripts/Game/UI/HUD/Elements/CSI_Radar.c
@@ -10,6 +10,7 @@ class CSI_Radar : SCR_ScriptedWidgetComponent
 	
 	protected int m_iStoredGroupCount = -1;
 	protected ref array<Widget> m_aRadarIcons;
+	protected ref array<CSI_Icon> m_aRadarIconHandlers;
 
 	protected static int ICON_WIDTH_AND_HEIGHT = 16;
 
@@ -27,6 +28,15 @@ class CSI_Radar : SCR_ScriptedWidgetComponent
 		m_HUDSystem = CSI_HUDSystem.GetInstance();
 		
 		m_aRadarIcons = CSI_UIHelper.GetAllIcons(m_wRoot, "RadarIcon", 25);
+
+		m_aRadarIconHandlers = {};
+		foreach (Widget radarIcon : m_aRadarIcons)
+		{
+			if (radarIcon)
+				m_aRadarIconHandlers.Insert(CSI_Icon.Cast(radarIcon.FindHandler(CSI_Icon)));
+			else
+				m_aRadarIconHandlers.Insert(null);
+		};
 	}
 
 //=============================================================================================================================================================================================================================================================================================================================================================
@@ -125,7 +135,7 @@ class CSI_Radar : SCR_ScriptedWidgetComponent
 			if (iconOpacity == 0 && iconOpacity == opacity)
 				return;
 			
-			CSI_Icon icon = CSI_Icon.Cast(radarIcon.FindHandler(CSI_Icon));
+			CSI_Icon icon = m_aRadarIconHandlers[widgetNumber];
 			
 			icon.IconUpdate(playerID);
 			

--- a/Scripts/Game/UI/Vanilla Overrides/Nametags/CSI_SCR_NameTagDisplay.c
+++ b/Scripts/Game/UI/Vanilla Overrides/Nametags/CSI_SCR_NameTagDisplay.c
@@ -4,6 +4,8 @@
 modded class SCR_NameTagDisplay : SCR_InfoDisplayExtended
 {
 	protected CSI_SettingsManager m_SettingsManager;
+	protected SCR_NameTagZone m_CachedNearZone;
+	protected int m_iLastNametagsRange = -1;
 
 	//------------------------------------------------------------------------------------------------
 	override void DisplayUpdate(IEntity owner, float timeSlice)
@@ -24,11 +26,20 @@ modded class SCR_NameTagDisplay : SCR_InfoDisplayExtended
 		if (!m_SettingsManager.GetSettingBool(CSI_GameSettings.NAMETAG_VISIBLE))
 			nametagsRange = 1;
 
-		foreach (SCR_NameTagZone nTZone : GetNametagZones()) 
-			if (nTZone.GetZoneName() == "Near")
-				nTZone.SetZoneEnd(nametagsRange);
+		if (nametagsRange != m_iLastNametagsRange)
+		{
+			m_iLastNametagsRange = nametagsRange;
 
-		s_NametagCfg.ResetFarthestZone();
+			if (!m_CachedNearZone)
+				foreach (SCR_NameTagZone nTZone : GetNametagZones())
+					if (nTZone.GetZoneName() == "Near")
+						m_CachedNearZone = nTZone;
+
+			if (m_CachedNearZone)
+				m_CachedNearZone.SetZoneEnd(nametagsRange);
+
+			s_NametagCfg.ResetFarthestZone();
+		}
 	}
 }
 

--- a/Scripts/Game/UI/Vanilla Overrides/Nametags/CSI_SCR_VehicleTagData.c
+++ b/Scripts/Game/UI/Vanilla Overrides/Nametags/CSI_SCR_VehicleTagData.c
@@ -15,11 +15,11 @@ modded class SCR_VehicleTagData
 		IEntity pilot = Vehicle.Cast(m_Entity).GetPilot();
 		if (pilot)
 		{
+			VehicleHelicopterSimulation heloSim = VehicleHelicopterSimulation.Cast(m_Entity.FindComponent(VehicleHelicopterSimulation));
+			VehicleFixedWingSimulation planeSim = VehicleFixedWingSimulation.Cast(m_Entity.FindComponent(VehicleFixedWingSimulation));
+
 			foreach (SCR_NameTagData tagData : m_aPassengers)
 			{
-				VehicleHelicopterSimulation heloSim = VehicleHelicopterSimulation.Cast(m_Entity.FindComponent(VehicleHelicopterSimulation));
-				VehicleFixedWingSimulation planeSim = VehicleFixedWingSimulation.Cast(m_Entity.FindComponent(VehicleFixedWingSimulation));
-					
 				if (tagData.m_Entity == pilot && (heloSim || planeSim))
 					localMainTag = tagData;
 			}


### PR DESCRIPTION
For your consideration:

- Hoisted FindComponent(VehicleHelicopterSimulation) and FindComponent(VehicleFixedWingSimulation) out of the passenger loop. They queried the same vehicle entity N times per UpdateMainTag call.

- Added a m_aRadarIconHandlers array that caches CSI_Icon references at HandlerAttached time. UpdatePlayerRadarWidget now reads from it instead of calling FindHandler (a linear component scan) for every radar slot every frame.

- Added m_CachedNearZone and m_iLastNametagsRange. The zone string-scan and ResetFarthestZone() (which re-scans all zones and recomputes square distances) now only run when nametagsRange actually changes, rather than every frame.

- Moved array<BaseMuzzleComponent> muzzles allocation before the item loop; now uses muzzles.Clear() per weapon instead of allocating a new array per weapon.

- Moved array<string> outPlayerStrArray before the sort-decode loop; now uses .Clear() per iteration instead of allocating a new array per group member each update cycle.